### PR TITLE
Feature update node check

### DIFF
--- a/src/NetworkUtil.ts
+++ b/src/NetworkUtil.ts
@@ -6,7 +6,7 @@ export class NetworkUtil {
   public static async getNodeFromNetwork(networkType: NetworkType) {
     const available_nodes = NetworkConfig.networks[networkType].nodes;
     for (const node of available_nodes) {
-      const nodeIsUp = await this.nodeIsUp(`${node.url}/node/health`);
+      const nodeIsUp = await this.nodeIsUp(node.url);
       if (nodeIsUp) {
         return node;
       }
@@ -15,7 +15,8 @@ export class NetworkUtil {
   }
 
   public static async nodeIsUp(nodeUrl: string) {
-    const res = await axios.get(nodeUrl).catch(() => {
+    nodeUrl = nodeUrl.replace(/\/$/, '');
+    const res = await axios.get(`${nodeUrl}/node/health`).catch(() => {
       return false;
     });
     if (res.data && res.data.status.apiNode === 'up' && res.data.status.db === 'up') {

--- a/test/NetworkUtil.spec.ts
+++ b/test/NetworkUtil.spec.ts
@@ -72,7 +72,7 @@ describe('NetworkUtil', () => {
         // THEN
         expect(result).to.not.be.undefined;
         expect(result).to.be.true;
-        sinon.assert.called(stubA);
+        sinon.assert.calledWith(stubA, 'test_url/node/health');
     });
 
     it('node is up expect result: false', async () => {
@@ -81,12 +81,12 @@ describe('NetworkUtil', () => {
         const stubA = sinon.stub(axios, 'get').returns(Promise.resolve(res));
 
         // WHEN
-        const result = await NetworkUtil.nodeIsUp('test_url');
+        const result = await NetworkUtil.nodeIsUp('test_url/');
 
         // THEN
         expect(result).to.not.be.undefined;
         expect(result).to.be.false;
-        sinon.assert.called(stubA);
+        sinon.assert.calledWith(stubA, 'test_url/node/health');
     });
 
     it('node is up expect error handling: return false', async () => {
@@ -100,7 +100,7 @@ describe('NetworkUtil', () => {
         // THEN
         expect(result).to.not.be.undefined;
         expect(result).to.be.false;
-        sinon.assert.called(stubA);
+        sinon.assert.calledWith(stubA, 'test_url/node/health');
     });
 
     it('get network type from address MAINNET', async () => {


### PR DESCRIPTION
- Check & remove trailing slash of the url.
- Append `/node/health` at the end of url.
- Update method `NetworkUtil.getNodeFromNetwork()` to pass the node url only (no `/node/health`).